### PR TITLE
Add ranger support

### DIFF
--- a/after/plugin/NERDTree.vim
+++ b/after/plugin/NERDTree.vim
@@ -1,3 +1,7 @@
+if executable('ranger')
+    finish
+endif
+
 " NERDTree
 nmap <Leader>n :NERDTreeToggle<CR>
 nmap <Leader>m :NERDTreeFind<CR>

--- a/after/plugin/general.vim
+++ b/after/plugin/general.vim
@@ -1,5 +1,8 @@
 filetype plugin indent on     " required!
 
+" https://github.com/francoiscabrol/ranger.vim/issues/42
+set shell=bash
+
 " this deletes  symbols(mostly at the end of the lines)
 " noremap <Leader>m mmHmt:%s/<C-V><cr>//ge<cr>'tzt'm
 

--- a/after/plugin/ranger.vim
+++ b/after/plugin/ranger.vim
@@ -1,0 +1,5 @@
+if !executable('ranger')
+    finish
+endif
+
+map <leader>f :Ranger<CR>

--- a/after/plugin/ranger.vim
+++ b/after/plugin/ranger.vim
@@ -3,3 +3,6 @@ if !executable('ranger')
 endif
 
 map <leader>f :Ranger<CR>
+" temporary measure
+nmap <Leader>n :Ranger<CR>
+nmap <Leader>m :Ranger<CR>

--- a/init.vim
+++ b/init.vim
@@ -24,7 +24,16 @@ call plug#begin()
             \ ] }
 
     Plug 'vim-scripts/TaskList.vim', { 'on':  'TaskList' }
-    Plug 'scrooloose/nerdtree', {
+
+    if executable('ranger')
+        " ranger is awesome
+        let g:ranger_replace_netrw = 1
+
+        Plug 'francoiscabrol/ranger.vim'
+
+        Plug 'rbgrouleff/bclose.vim'
+    else
+        Plug 'scrooloose/nerdtree', {
             \ 'on': [
                 \ 'NERDTree',
                 \ 'NERDTreeCWD',
@@ -35,6 +44,7 @@ call plug#begin()
                 \ 'NERDTreeMirror',
                 \ 'NERDTreeToggle'
             \ ] }
+    endif
 
     Plug 'voldikss/vim-floaterm', {
             \ 'on': [

--- a/init.vim
+++ b/init.vim
@@ -26,6 +26,8 @@ call plug#begin()
     Plug 'vim-scripts/TaskList.vim', { 'on':  'TaskList' }
 
     if executable('ranger')
+        let g:ranger_command_override = 'ranger --cmd "set show_hidden=true"'
+
         " ranger is awesome
         let g:ranger_replace_netrw = 1
 

--- a/regexlist.vim
+++ b/regexlist.vim
@@ -7,3 +7,12 @@ let requireImport = "\\v(const|var|let)\\s*(\\S*|\\{[^\\}]*\\})\\s*\\=\\s*requir
 let functionArrow = "\\vfunction\\s*(\\S*)\\s*(\\([^)]*\\))/const \\1 = \\2 =>"
 
 let markdownLinks = "\\%V\\v(.*)/[\\1](\\1)"
+
+let kebab2pascal = "\\%V\\v(^|-)([a-z])/\\U\\2"
+let snake2pascal = "\\%V\\v(^|_)([a-z])/\\U\\2"
+let kebab2camel = "\\%V\\v-([a-z])/\\U\\1"
+let snake2camel = "\\%V\\v_([a-z])/\\U\\1"
+let camel2kebab = "\\%V\\v([A-Z])/-\\L\\1"
+let camel2snake = "\\%V\\v([A-Z])/_\\L\\1"
+let pascal2kebab = "\\%V\\v([A-Z])/-\\L\\1"
+let pascal2snake = "\\%V\\v([A-Z])/_\\L\\1"


### PR DESCRIPTION
- [ ] in vim after `vim .` and after selecting a file arrow keys fail, i.e.:
```E388: Couldn't find definition```